### PR TITLE
[RELEASE] v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Section Order:
 ### Security
 -->
 
+## [2.5.0] - 2025-06-03
+
+### Changed
+
+- Translations updated
+
 ### Removed
 
 - Cache breaker for static files. Doesn't work as expected with `django-sri`.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Restart your supervisor services for AA
 Add the app to your `conf/requirements.txt`
 
 ```text
-aa-discord-announcements==2.4.3
+aa-discord-announcements==2.5.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>

--- a/aa_discord_announcements/__init__.py
+++ b/aa_discord_announcements/__init__.py
@@ -5,5 +5,5 @@ A couple of variables to use throughout the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.4.3"
+__version__ = "2.5.0"
 __title__ = _("Discord Announcements")

--- a/aa_discord_announcements/locale/django.pot
+++ b/aa_discord_announcements/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Discord Announcements 2.4.3\n"
+"Project-Id-Version: AA Discord Announcements 2.5.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-discord-announcements/issues\n"
-"POT-Creation-Date: 2025-05-05 20:33+0200\n"
+"POT-Creation-Date: 2025-06-03 10:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.5.0] - 2025-06-03

### Changed

- Translations updated

### Removed

- Cache breaker for static files. Doesn't work as expected with `django-sri`.
