### PR TITLE
[RELEASE] v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,14 @@ Section Order:
 ### Security
 -->
 
+## [2.6.0] - 2025-08-14
+
 ### Changed
 
 - Use AA framework JS functions
 - Minimum requirements
   - Alliance Auth >= 4.9.0
+- Translations updated
 
 ## [2.5.3] - 2025-08-08
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Restart your supervisor services for AA
 Add the app to your `conf/requirements.txt`
 
 ```text
-aa-discord-announcements==2.5.3
+aa-discord-announcements==2.6.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>

--- a/aa_discord_announcements/__init__.py
+++ b/aa_discord_announcements/__init__.py
@@ -5,5 +5,5 @@ A couple of variables to use throughout the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.5.3"
+__version__ = "2.6.0"
 __title__ = _("Discord Announcements")

--- a/aa_discord_announcements/locale/django.pot
+++ b/aa_discord_announcements/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Discord Announcements 2.5.3\n"
+"Project-Id-Version: AA Discord Announcements 2.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-discord-announcements/issues\n"
-"POT-Creation-Date: 2025-08-08 11:07+0200\n"
+"POT-Creation-Date: 2025-08-14 06:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.6.0] - 2025-08-14

### Changed

- Use AA framework JS functions
- Minimum requirements
  - Alliance Auth >= 4.9.0
- Translations updated
