### PR TITLE
[RELEASE] v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [3.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -460,6 +462,7 @@ Section Order:
 [2.7.2]: https://github.com/ppfeufer/aa-discord-announcements/compare/v2.7.1...v2.7.2 "v2.7.2"
 [2.7.3]: https://github.com/ppfeufer/aa-discord-announcements/compare/v2.7.2...v2.7.3 "v2.7.3"
 [2.8.0]: https://github.com/ppfeufer/aa-discord-announcements/compare/v2.7.3...v2.8.0 "v2.8.0"
-[in development]: https://github.com/ppfeufer/aa-discord-announcements/compare/v2.8.0...HEAD "In Development"
+[3.0.0]: https://github.com/ppfeufer/aa-discord-announcements/compare/v2.8.0...v3.0.0 "v3.0.0"
+[in development]: https://github.com/ppfeufer/aa-discord-announcements/compare/v3.0.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Restart your supervisor services for AA
 Add the app to your `conf/requirements.txt`
 
 ```text
-aa-discord-announcements==2.8.0
+aa-discord-announcements==3.0.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>

--- a/aa_discord_announcements/__init__.py
+++ b/aa_discord_announcements/__init__.py
@@ -5,6 +5,6 @@ A couple of variables to use throughout the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.8.0"
+__version__ = "3.0.0"
 __title__ = "Discord Announcements"
 __title_translated__ = _("Discord Announcements")


### PR DESCRIPTION
## [3.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Removed

- Support for Alliance Auth v4
